### PR TITLE
Makefile の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,4 +216,4 @@ pseudoxml:
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 livehtml:
-  sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html


### PR DESCRIPTION
Makefile に一部スペースが存在していたため、tabに修正

* local 環境で `make html` がコケたため